### PR TITLE
Add new event fields to classic web events

### DIFF
--- a/OVRUI/src/Inputs/KeyboardEventInput.js
+++ b/OVRUI/src/Inputs/KeyboardEventInput.js
@@ -49,7 +49,7 @@ export default class KeyboardEventInput extends EventInput {
   }
 
   _onKeyboardEvent(e: KeyboardEvent) {
-    this._batchedEvents.push({
+    const event = {
       type: this.getEventType(),
       eventType: e.type,
       altKey: e.altKey,
@@ -60,7 +60,20 @@ export default class KeyboardEventInput extends EventInput {
       metaKey: e.metaKey,
       repeat: e.repeat,
       shiftKey: e.shiftKey,
-    });
+    };
+
+    // New event fields
+    if (e.repeat) {
+      event.action = 'repeat';
+    } else if (e.type === 'keydown') {
+      event.action = 'down';
+    } else if (e.type === 'keyup') {
+      event.action = 'up';
+    }
+    if (e.keyCode === 13 || e.keyCode === 32) {
+      event.buttonClass = 'confirm';
+    }
+    this._batchedEvents.push(event);
   }
 
   getEvents(): null | Array<KeyboardInputEvent> {

--- a/OVRUI/src/Inputs/MouseEventInput.js
+++ b/OVRUI/src/Inputs/MouseEventInput.js
@@ -83,12 +83,13 @@ export default class MouseEventInput extends EventInput {
   _onMouseEvent(e: MouseEvent) {
     const target = e.currentTarget;
     if (target && target === this._target) {
-      const viewport = typeof target.getBoundingClientRect === 'function'
-        ? target.getBoundingClientRect()
-        : getDocumentBounds();
+      const viewport =
+        typeof target.getBoundingClientRect === 'function'
+          ? target.getBoundingClientRect()
+          : getDocumentBounds();
       const viewportX = (e.clientX - viewport.left) / viewport.width * 2 - 1;
       const viewportY = -((e.clientY - viewport.top) / viewport.height) * 2 + 1;
-      this._batchedEvents.push({
+      const event = {
         type: this.getEventType(),
         eventType: e.type,
         altKey: e.altKey,
@@ -99,7 +100,17 @@ export default class MouseEventInput extends EventInput {
         shiftKey: e.shiftKey,
         viewportX: viewportX,
         viewportY: viewportY,
-      });
+      };
+      // New event fields
+      if (e.type === 'mousedown') {
+        event.action = 'down';
+      } else if (e.type === 'mouseup') {
+        event.action = 'up';
+      }
+      if (e.button === 0) {
+        event.buttonClass = 'confirm';
+      }
+      this._batchedEvents.push(event);
     }
   }
 

--- a/OVRUI/src/Inputs/TouchEventInput.js
+++ b/OVRUI/src/Inputs/TouchEventInput.js
@@ -117,7 +117,14 @@ export default class TouchEventInput extends EventInput {
         shiftKey: e.shiftKey,
         targetTouches: createTouchList((e: any).targetTouches, viewport),
         touches: createTouchList(e.touches, viewport),
+        buttonClass: 'confirm',
       };
+      // New event fields
+      if (e.type === 'touchstart') {
+        touchEvent.action = 'down';
+      } else if (e.type === 'touchend' || e.type === 'touchcancel') {
+        touchEvent.action = 'up';
+      }
       this._batchedEvents.push(touchEvent);
       if (this._immediateListener) {
         this._immediateListener(touchEvent);


### PR DESCRIPTION
Summary: Add `action` and `buttonClass` fields to all of the input even generators, so they can be standardized and used for cleaner VrButton later

Reviewed By: mikearmstrong001

Differential Revision: D6934490

fbshipit-source-id: b8d353fb53ab7bed2e38376f8d2d964beac07619

Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.

## Motivation (required)

What existing problem does the pull request solve?

## Test Plan (required)

A good test plan has the exact commands you ran and their output, provides screenshots or videos if the pull request changes UI or updates the website. See [What is a Test Plan?][1] to learn more.  

If you have added code that should be tested, add tests.

## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on [Circle CI][3]. PRs that break tests are unlikely to be merged.

For more info, see the ["Pull Requests"][4] section of our "Contributing" guidelines.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: http://circleci.com/gh/facebook/react-native
[4]: https://github.com/facebook/react-vr/blob/master/CONTRIBUTING.md#pull-requests
