### PR TITLE
Allow fading environment to black with null src

### DIFF
--- a/ReactVR/js/Compositor/Environment/Environment.js
+++ b/ReactVR/js/Compositor/Environment/Environment.js
@@ -158,18 +158,22 @@ export default class Environment {
     return this._panoMesh;
   }
 
-  setSource(src: string, options: PanoOptions = {}): Promise<void> {
+  setSource(src: null | string, options: PanoOptions = {}): Promise<void> {
     if (this._resourceManager && this._panoSource) {
       this._resourceManager.removeReference(this._panoSource);
     }
     const oldSrc = this._panoSource;
     this._panoSource = src;
-    this._panoLoad = this._loadImage(src, options);
     const duration =
       typeof options.transition === 'number' ? options.transition : 500;
     // If the duration is zero, set the transition to complete on the next frame
     const transition = duration ? 1 / duration : 1;
     this._panoTransition = oldSrc ? -transition : 0;
+    if (!src) {
+      this._panoLoad = null;
+      return Promise.resolve();
+    }
+    this._panoLoad = this._loadImage(src, options);
     return this._panoLoad.then(data => {
       if (this._panoTransition === 0) {
         this._panoLoad = null;


### PR DESCRIPTION
Summary: Pretty simple, setting environment to null will allow the environment to fade to black

Reviewed By: larrylin28

Differential Revision: D7539022

fbshipit-source-id: 8c58424a722738e0d806c9f96749172f107cf350

Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.

## Motivation (required)

What existing problem does the pull request solve?

## Test Plan (required)

A good test plan has the exact commands you ran and their output, provides screenshots or videos if the pull request changes UI or updates the website. See [What is a Test Plan?][1] to learn more.  

If you have added code that should be tested, add tests.

## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on [Circle CI][3]. PRs that break tests are unlikely to be merged.

For more info, see the ["Pull Requests"][4] section of our "Contributing" guidelines.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: http://circleci.com/gh/facebook/react-native
[4]: https://github.com/facebook/react-vr/blob/master/CONTRIBUTING.md#pull-requests
